### PR TITLE
udpate yaml.load to safe_loader

### DIFF
--- a/src/ansibleautodoc/Annotation.py
+++ b/src/ansibleautodoc/Annotation.py
@@ -272,7 +272,7 @@ class Annotation:
 
                 with open(file, 'r',encoding='utf8') as yaml_file:
                     try:
-                        data = yaml.load(yaml_file)
+                        data = yaml.load(yaml_file, Loader=yaml.SafeLoader)
                         tags_found = Annotation.find_tag("tags",data)
 
                         for tag in tags_found:


### PR DESCRIPTION
Update the yaml.load(input) function to remove the deprecated warning as seen in https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
I've chosen the SafeLoder because the yaml file is from the user and we should never trust the user's input.